### PR TITLE
check IEEE_ADDR_NODE_ID at compile time

### DIFF
--- a/cpu/cc26xx/ieee-addr.c
+++ b/cpu/cc26xx/ieee-addr.c
@@ -81,10 +81,10 @@ ieee_addr_cpy_to(uint8_t *dst, uint8_t len)
     }
   }
 
-#if IEEE_ADDR_NODE_ID
-  dst[len - 1] = IEEE_ADDR_NODE_ID & 0xFF;
-  dst[len - 2] = IEEE_ADDR_NODE_ID >> 8;
-#endif
+  if(IEEE_ADDR_NODE_ID){
+    dst[len - 1] = IEEE_ADDR_NODE_ID & 0xFF;
+    dst[len - 2] = IEEE_ADDR_NODE_ID >> 8;
+  }
 }
 /*---------------------------------------------------------------------------*/
 /** @} */

--- a/cpu/cc26xx/ieee-addr.h
+++ b/cpu/cc26xx/ieee-addr.h
@@ -85,6 +85,10 @@
 #endif
 /** @} */
 /*---------------------------------------------------------------------------*/
+#ifndef IEEE_ADDR_NODE_ID
+#define IEEE_ADDR_NODE_ID (0)
+#endif
+/*---------------------------------------------------------------------------*/
 /**
  * \brief Copy the node's IEEE address to a destination memory area
  * \param dst A pointer to the destination area where the IEEE address is to be


### PR DESCRIPTION
This allows the compiler to check the code gaurded by IEEE_ADDR_NODE_ID and
also allows us to define IEEE_ADDR_NODE_ID to a variable.